### PR TITLE
Run check with old R/package versions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -24,10 +24,13 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
+          - {os: ubuntu-20.04, r: '3.5', repos: "https://cran.microsoft.com/snapshot/2019-03-11/"}
+          - {os: ubuntu-20.04, r: '3.6', repos: "https://cran.microsoft.com/snapshot/2020-02-29/"}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
+      REPOS: ${{ matrix.config.repos }}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -66,6 +69,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          repos <- Sys.getenv("REPOS")
+          if (repos != "") options(repos = repos)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}


### PR DESCRIPTION
As mentioned in #2 I added two additional runs to your `R CMD check`'s matrix config. These are R 3.5 and R 3.6 with packages installed using MRAN snapshots from the release dates of version 3.5.3 and 3.6.3. If you want to keep backward compatibility going forward then I'd suggest to include this in your workflow. 