### PR TITLE
resolve issue in xml_to_value_spec() when no VLM in define.xml

### DIFF
--- a/R/xml_builders.R
+++ b/R/xml_builders.R
@@ -229,6 +229,13 @@ xml_to_value_spec <- function(doc) {
          )
       }
       )
+   # create 0x4 tibble if where_eqs is 0x0
+   # tmp workaround until below bug is resolved in purrr
+   # https://github.com/tidyverse/purrr/issues/824
+   if(nrow(where_eqs) == 0){
+      where_eqs <- c("where_oid", "left", "test", "right") %>%
+         map_dfr(setNames, object = list(character()))
+   }
 
    if(nrow(where_to_merge) == 0){
       where_eqs <- where_eqs %>%


### PR DESCRIPTION
#64 is resolved in `blank_val` branch for excel spec. 
`define_to_metacore()` fails when no value level in `define.xml`, due to [this unresolved issue in purrr](https://github.com/tidyverse/purrr/issues/824), temporary workaround added to `xml_to_value_spec()`
