### PR TITLE
Don't use an anonymous function in `across()`

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -65,10 +65,7 @@ basic_check <- function(col_to_check, metacore){
       group_by(var1) %>%
       mutate(n_lab = n_distinct({{col_to_check}})) %>%
       filter(n_lab > 1) %>%
-      mutate(across(everything(), function(x){
-         attr(x, "label") <- NULL
-         x
-      })) %>%
+      mutate(across(everything(), remove_label)) %>%
       group_by(var1, {{col_to_check}}) %>%
       summarise(n_vars = n(),
                 ls_of_vars = list(variable),
@@ -81,4 +78,9 @@ basic_check <- function(col_to_check, metacore){
    } else {
       message(str_glue("No mismatch {as_label(enexpr(col_to_check))}s detected"))
    }
+}
+
+remove_label <- function(x) {
+   attr(x, "label") <- NULL
+   x
 }


### PR DESCRIPTION
We are releasing a new version of dplyr today, but we just noticed that your package came up in our revdep check.

There is an incredibly rare bug that can occur with the combination of:
- `across()`
- An anonymous function
- That function uses assignment like `<-`

You can read more about it here if you want https://github.com/tidyverse/dplyr/issues/6666

We plan to fix this somehow, but it is technically challenging and will take us some time.

Unfortunately metacore was affected by this bug. It is an easy fix though, we can just turn the anonymous function into a real function.

We still plan to send in dplyr 1.1.0 today since only metacore was affected by this. We apologize for the short notice here.