### PR TITLE
#120 Bug fixed: suppress warnings like on load

### DIFF
--- a/R/metacore.R
+++ b/R/metacore.R
@@ -22,46 +22,46 @@ MetaCore_initialize <- function(ds_spec, ds_vars, var_spec, value_spec, derivati
 
    private$.ds_spec <- ds_spec %>%
       add_labs(dataset = "Dataset Name",
-                 structure = "Value Structure",
-                 label = "Dataset Label")
+               structure = "Value Structure",
+               label = "Dataset Label")
 
    private$.ds_vars <- ds_vars %>%
       add_labs(dataset = "Dataset Name",
-                 variable = "Variable Name",
-                 key_seq = "Sequence Key",
-                 order = "Variable Order",
-                 keep = "Keep (Boolean)",
-                 core = "ADaM core (Expected, Required, Permissible)",
-                 supp_flag = "Supplemental Flag")
+               variable = "Variable Name",
+               key_seq = "Sequence Key",
+               order = "Variable Order",
+               keep = "Keep (Boolean)",
+               core = "ADaM core (Expected, Required, Permissible)",
+               supp_flag = "Supplemental Flag")
 
    private$.var_spec <- var_spec %>%
       add_labs(variable = "Variable Name",
-                 length = "Variable Length",
-                 label = "Variable Label",
-                 type = "Variable Class",
-                 common = "Common Across ADaM",
-                 format = "Variable Format")
+               length = "Variable Length",
+               label = "Variable Label",
+               type = "Variable Class",
+               common = "Common Across ADaM",
+               format = "Variable Format")
 
    private$.value_spec <- value_spec %>%
       add_labs(type = "Value Type",
-                 orgin = "Origin of Value",
-                 code_id = "ID of the Code List",
-                 dataset = "Dataset Name",
-                 variable = "Variable Name",
-                 where = "Value of the Variable",
-                 derivation_id = "ID of Derivation") %>%
+               orgin = "Origin of Value",
+               code_id = "ID of the Code List",
+               dataset = "Dataset Name",
+               variable = "Variable Name",
+               where = "Value of the Variable",
+               derivation_id = "ID of Derivation") %>%
       mutate(origin = str_to_lower(.data$origin))
 
 
    private$.derivations <- derivations %>%
       add_labs(derivation_id = "ID of Derivation",
-                 derivation = "Derivation")
+               derivation = "Derivation")
 
    private$.codelist <- codelist %>%
       add_labs(code_id = "ID of the Code List",
-                 names = "Name of the Code List",
-                 type = "Code List/Permitted Values/External Library",
-                 codes = "List of Codes")
+               names = "Name of the Code List",
+               type = "Code List/Permitted Values/External Library",
+               codes = "List of Codes")
 
    private$.codelist <- codelist %>%
       add_labs(code_id = "ID of the Code List",
@@ -80,8 +80,14 @@ MetaCore_initialize <- function(ds_spec, ds_vars, var_spec, value_spec, derivati
    private$.ds_names <- ds_spec %>% pull(dataset)
 
    private$.ds_labels <- ds_spec %>% pull(label)
+   if(quiet){
+      suppressWarnings(self$validate())
+   }
+   else {
+      self$validate()
+   }
 
-   self$validate()
+
    if (inherits_only(self, c("Metacore", "R6"))) { private$.greet(quiet) }
 }
 
@@ -115,14 +121,14 @@ MetaCore_validate <-  function() {
    if(var_name_check(private)){
 
       if(nrow(private$.ds_spec) == 0 &
-      nrow(private$.ds_vars) == 0 &
-      nrow(private$.var_spec) == 0 &
-      nrow(private$.value_spec) == 0 &
-      nrow(private$.derivations) == 0 &
-      nrow(private$.codelist) == 0 &
-      nrow(private$.supp) == 0 ){
+         nrow(private$.ds_vars) == 0 &
+         nrow(private$.var_spec) == 0 &
+         nrow(private$.value_spec) == 0 &
+         nrow(private$.derivations) == 0 &
+         nrow(private$.codelist) == 0 &
+         nrow(private$.supp) == 0 ){
          cli_warn("Other checks were not preformed, because all datasets are empty",
-                 call. = FALSE)
+                  call. = FALSE)
       } else {
          check_columns(private$.ds_spec,
                        private$.ds_vars,
@@ -145,7 +151,7 @@ MetaCore_validate <-  function() {
 
    } else {
       cli_warn("Other checks were not preformed, because column names were incorrect",
-              call. = FALSE)
+               call. = FALSE)
    }
 }
 
@@ -228,85 +234,85 @@ MetaCore_filter <- function(value) {
 #' @noRd
 #
 MetaCore <- R6::R6Class("Metacore",
-  public = list(
-     initialize = MetaCore_initialize,
-     print = MetaCore_print,
-     validate =  MetaCore_validate,
-     metacore_filter = MetaCore_filter
-  ),
+                        public = list(
+                           initialize = MetaCore_initialize,
+                           print = MetaCore_print,
+                           validate =  MetaCore_validate,
+                           metacore_filter = MetaCore_filter
+                        ),
 
-  private = list(
-     .ds_spec = tibble(
-        dataset = character(),
-        structure = character(),
-        label = character()
-     ),
-     .ds_vars = tibble(
-        dataset = character(),
-        variable = character(),
-        keep = logical(),
-        key_seq = integer(),
-        order = integer(),
-        core = character(),
-        supp_flag = logical()
-     ),
-     .var_spec = tibble(
-        variable = character(),
-        label = character(),
-        length = integer(),
-        type = character(),
-        common = character(),
-        format = character()
-     ),
-     .value_spec = tibble(
-        dataset = character(),
-        variable = character(),
-        where  = character(),
-        type = character(),
-        sig_dig = integer(),
-        code_id = character(),
-        origin = character(),
-        derivation_id = integer()
-     ),
-     .derivations = tibble(
-        derivation_id = integer(),
-        derivation = character()
-     ),
-     # code_type == df | permitted_val | external_lib
-     .codelist = tibble(
-        code_id = character(),
-        name = character(),
-        type = character(),
-        codes = list()
-     ),
-     .supp = tibble(
-        dataset = character(),
-        variable = character(),
-        idvar = character(),
-        qeval = character()
-     ),
-     .ds_len = NA,
-     .ds_names = list(),
-     .ds_labels = list(),
+                        private = list(
+                           .ds_spec = tibble(
+                              dataset = character(),
+                              structure = character(),
+                              label = character()
+                           ),
+                           .ds_vars = tibble(
+                              dataset = character(),
+                              variable = character(),
+                              keep = logical(),
+                              key_seq = integer(),
+                              order = integer(),
+                              core = character(),
+                              supp_flag = logical()
+                           ),
+                           .var_spec = tibble(
+                              variable = character(),
+                              label = character(),
+                              length = integer(),
+                              type = character(),
+                              common = character(),
+                              format = character()
+                           ),
+                           .value_spec = tibble(
+                              dataset = character(),
+                              variable = character(),
+                              where  = character(),
+                              type = character(),
+                              sig_dig = integer(),
+                              code_id = character(),
+                              origin = character(),
+                              derivation_id = integer()
+                           ),
+                           .derivations = tibble(
+                              derivation_id = integer(),
+                              derivation = character()
+                           ),
+                           # code_type == df | permitted_val | external_lib
+                           .codelist = tibble(
+                              code_id = character(),
+                              name = character(),
+                              type = character(),
+                              codes = list()
+                           ),
+                           .supp = tibble(
+                              dataset = character(),
+                              variable = character(),
+                              idvar = character(),
+                              qeval = character()
+                           ),
+                           .ds_len = NA,
+                           .ds_names = list(),
+                           .ds_labels = list(),
 
-     .greet = function(quiet = FALSE) {
-        cli_par()
-        cli_alert_success("Metadata successfully imported")
-        if (quiet) cli_inform(c("i" = col_red("Dataset metadata imported with suppressed warnings")))
-        cli_inform(c("i" = "To use the {.obj Metacore} object with {.pkg metatools} package, first subset a dataset using {.fn metacore::select_dataset}"))
-        cli_end()
-     }
-   ),
+                           .greet = function(quiet = FALSE) {
+                              cli_par()
+                              cli_alert_success("Metadata successfully imported")
+                              if (quiet) cli_inform(c("i" = col_red("Dataset metadata imported with suppressed warnings")))
+                              cli_inform(c("i" = "To use the {.obj Metacore} object with {.pkg metatools} package, first subset a dataset using {.fn metacore::select_dataset}"))
+                              cli_end()
+                           }
+                        ),
 
-  active = list(
-     ds_spec = readonly('ds_spec'),
-     ds_vars =  readonly('ds_vars'),
-     var_spec = readonly('var_spec'),
-     value_spec = readonly('value_spec'),
-     derivations = readonly('derivations'),
-     codelist = readonly('codelist'),
-     supp = readonly('supp')
-  )
+                        active = list(
+                           ds_spec = readonly('ds_spec'),
+                           ds_vars =  readonly('ds_vars'),
+                           var_spec = readonly('var_spec'),
+                           value_spec = readonly('value_spec'),
+                           derivations = readonly('derivations'),
+                           codelist = readonly('codelist'),
+                           supp = readonly('supp')
+                        )
 )
 
 
@@ -328,8 +334,8 @@ MetaCore <- R6::R6Class("Metacore",
 #'
 metacore <- function(ds_spec = tibble(dataset = character(), structure = character(), label = character()),
                      ds_vars = tibble(dataset = character(), variable = character(), keep = logical(),
-                                       key_seq = integer(), order = integer(), core = character(),
-                                       supp_flag = logical()),
+                                      key_seq = integer(), order = integer(), core = character(),
+                                      supp_flag = logical()),
                      var_spec = tibble(variable = character(), label = character(), length = integer(),
                                        type = character(), common = character(), format = character()),
                      value_spec = tibble(dataset = character(),
@@ -372,7 +378,7 @@ metacore <- function(ds_spec = tibble(dataset = character(), structure = charact
          })
       names(replaced) <- to_replace %>% map_chr(~unique(.$dataset))
       list2env(replaced, environment())
-      }
+   }
    MetaCore$new(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist, supp, quiet)
 }
 
@@ -395,7 +401,7 @@ select_dataset <- function(.data, dataset, simplify = FALSE, quiet = FALSE) {
    cl$metacore_filter(dataset)
 
    if (simplify) {
-     test <-  suppressMessages(
+      test <-  suppressMessages(
          list(
             cl$ds_vars,
             cl$var_spec,
@@ -528,14 +534,14 @@ save_metacore <- function(metacore_object, path = NULL) {
       nm <- deparse(substitute(metacore_object))
       path <- paste0(nm, ".rds")
 
-   # check the suffix of the path
+      # check the suffix of the path
    } else {
       suffix <- str_extract(path, "\\.\\w*$")
       # if the extension is .rda keep it
       if (suffix == ".rds") {
          path <- path
 
-      # otherwise we need to replace it with .rda
+         # otherwise we need to replace it with .rda
       } else {
          prefix <- str_remove(path, "\\.\\w*$")
          path <- paste0(prefix, ".rds")
@@ -557,7 +563,7 @@ load_metacore <- function(path = NULL) {
          cli_abort("please supply path to metacore object ending with extension .rds", call. = FALSE)
       } else {
          cli_abort("metacore object path required, did you mean:",
-              paste("   ", rdss, sep = "\n   "), call. = FALSE)
+                   paste("   ", rdss, sep = "\n   "), call. = FALSE)
       }
    }
    readRDS(path)

--- a/R/spec_builder.R
+++ b/R/spec_builder.R
@@ -23,14 +23,12 @@ spec_to_metacore <- function(path, quiet = FALSE, where_sep_sheet = TRUE){
       value_spec <- spec_type_to_value_spec(doc, where_sep_sheet = where_sep_sheet)
       derivations <- spec_type_to_derivations(doc)
       code_list <- spec_type_to_codelist(doc)
-      if(!quiet){
-         out <- metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list)
-      } else{
-         out<- suppressWarnings(metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list, quiet = quiet))
-      }
+
+      out <- metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list, quiet = quiet)
+
    } else {
       cli_abort("This specification format is not currently supported. You will need to write your own reader",
-           call. = FALSE)
+                call. = FALSE)
    }
    out
 }
@@ -49,14 +47,14 @@ spec_type <- function(path){
    sheets <- excel_sheets(path)
    if(!any(sheets %>% str_detect("[D|d]omains?|[D|d]atasets?"))){
       cli_abort("File does not contain a Domain/Datasets tab, which is needed. Please either modify the spec document or write a reader (see documentation for more information)",
-           call. = FALSE)
+                call. = FALSE)
    } else if(any(sheets %>% str_detect("ADSL|DM"))){
       type <- "by_ds"
    } else if(any(sheets %>% str_detect("[V|v]ariables?"))){
       type <- "by_type"
    } else {
       cli_abort("File in an unknown format. Please either modify the spec document or write a reader (see documentation for more information)",
-           call. = FALSE)
+                call. = FALSE)
    }
    type
 }
@@ -343,7 +341,7 @@ spec_type_to_value_spec <- function(doc, cols = c("dataset" = "[D|d]ataset|[D|d]
          "i" = "'dataset', 'variable', 'origin', 'code_id', 'type', 'where', 'sig_dig', 'derivation_id','predecessor'",
          "i" = paste("If derivation_id is not avaliable it can be excluded and dataset.variable will be used.",
                      "If the where information is on a seperate sheet, put the column with cross ref as where.")
-         ), call = FALSE)
+      ), call = FALSE)
    }
 
    # Select a subset of sheets if specified
@@ -406,15 +404,15 @@ spec_type_to_value_spec <- function(doc, cols = c("dataset" = "[D|d]ataset|[D|d]
          select(-where, where = where_new)
    } else if(where_sep_sheet) {
       cli_warn("Not able to add where infromation from seperate sheet cause a where column is needed to cross-reference the information",
-              call. = FALSE)
+               call. = FALSE)
    }
 
    if(!"derivation_id" %in% names(cols)){
       out <- out %>%
          mutate(derivation_id =
                    if_else(str_to_lower(.data$origin) == "assigned",
-                      paste0(dataset, ".", variable),
-                      paste0("pred.", dataset, ".", variable)))
+                           paste0(dataset, ".", variable),
+                           paste0("pred.", dataset, ".", variable)))
    }
 
    # Get missing columns
@@ -478,7 +476,7 @@ spec_type_to_codelist <- function(doc, codelist_cols = c("code_id" = "ID",
       if(!name_check| is.null(names(codelist_cols))){
          cli_abort("Supplied column vector for codelist_cols must be named using the following names:
               'code_id', 'name', 'code', 'decode'",
-              call. = FALSE
+                   call. = FALSE
          )
       }
    }
@@ -489,7 +487,7 @@ spec_type_to_codelist <- function(doc, codelist_cols = c("code_id" = "ID",
       if(!name_check){
          cli_abort("Supplied column vector for permitted_val_cols must be named using the following names:
               'code_id', 'name', 'code'",
-              call. = FALSE)
+                   call. = FALSE)
       }
    }
    if(!is.null(dict_cols)){
@@ -571,9 +569,9 @@ spec_type_to_derivations <- function(doc, cols = c("derivation_id" = "ID",
                                      sheet = "Method|Derivations?",
                                      var_cols = c("dataset" = "[D|d]ataset|[D|d]omain",
                                                   "variable" = "[N|n]ame|[V|v]ariables?",
-                                        "origin" = "[O|o]rigin",
-                                        "predecessor" = "[P|p]redecessor",
-                                        "comment" = "[C|c]omment")){
+                                                  "origin" = "[O|o]rigin",
+                                                  "predecessor" = "[P|p]redecessor",
+                                                  "comment" = "[C|c]omment")){
 
    name_check <- names(cols) %in% c("derivation_id", "derivation") %>%
       all()
@@ -615,7 +613,7 @@ spec_type_to_derivations <- function(doc, cols = c("derivation_id" = "ID",
             str_to_lower(.data$origin) == "predecessor" ~ paste0("pred.", as.character(.data$predecessor)),
             str_to_lower(.data$origin) == "assigned" ~ paste0(.data$dataset, ".", .data$variable),
             TRUE ~ NA_character_
-            ),
+         ),
          derivation = case_when(
             str_to_lower(.data$origin) == "predecessor" ~ as.character(.data$predecessor),
             str_to_lower(.data$origin) == "assigned" ~ .data$comment,
@@ -688,7 +686,7 @@ create_tbl <- function(doc, cols){
          }) %>%
          paste0(collapse = "\n") %>%
          paste0("Unable to identify a sheet with all columns.\n", . ) %>%
-        (call. = FALSE)
+         (call. = FALSE)
 
    } else if(length(matches) == 1){
       # Check names and write a better warning message if names don't work
@@ -751,7 +749,7 @@ yn_to_tf <- function(x){
       x
    } else {
       cli_warn("Keep column needs to be True or False, please correct before converting to a Metacore object",
-              call. = FALSE)
+               call. = FALSE)
       x
    }
 }

--- a/R/xml_builders.R
+++ b/R/xml_builders.R
@@ -24,11 +24,9 @@ define_to_metacore <- function(path, quiet = FALSE){
    value_spec <- xml_to_value_spec(xml)
    code_list <- xml_to_codelist(xml)
    derivations <- xml_to_derivations(xml)
-   if(!quiet){
-      out <- metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list)
-   } else{
-      out<- suppressWarnings(metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list, quiet = quiet))
-   }
+
+   out <- metacore(ds_spec, ds_vars, var_spec, value_spec, derivations, codelist = code_list, quiet = quiet)
+
    out
 }
 


### PR DESCRIPTION
Updated metacore.R to fix the bug to suppress the warnings when metacore() function was called directly. Refactor the suppress warnings in the metacore function while removing the updates from spec_builder and xml_builders functions. Message/Warning suppression now handled centrally in MetaCore_initialize().