### PR TITLE
Closes #110 Enable search bar on pkgdown website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,9 +1,15 @@
+url: https://atorus-research.github.io/metacore
+
 destination: docs
 
 template:
+  bootstrap: 5
   params:
     bootswatch: yeti
   opengraph:
     image:
       src: man/figures/metacore.PNG
       alt: "metacore Hex Sticker"
+
+search:
+  exclude: ['news/index.html']


### PR DESCRIPTION
- Enable search bar on pkgdown website 
- Upgrade to Bootstrap 5 and add url to resolve build warnings as follows:
 
<img width="1183" height="288" alt="image" src="https://github.com/user-attachments/assets/65db2158-af3c-4064-a2cf-22b8d36e7bab" />

 (#110)