### PR TITLE
Closes #108 error message update for `spec_to_metacore()`

### DIFF
--- a/R/spec_builder.R
+++ b/R/spec_builder.R
@@ -764,7 +764,7 @@ create_tbl <- function(doc, cols) {
       }) %>%
       paste0(collapse = "\n") %>%
       paste0("Unable to identify a sheet with all columns.\n", .) %>%
-      (call. <- FALSE)
+      cli_abort(call. = FALSE)
   } else if (length(matches) == 1) {
     # Check names and write a better warning message if names don't work
     ds_nm <- matches[[1]] %>% names()

--- a/tests/testthat/test-reader.R
+++ b/tests/testthat/test-reader.R
@@ -612,3 +612,36 @@ test_that("define_to_metacore(quiet) deprecation message is output when supplied
     spec <- define_to_metacore(metacore_example("ADaM_define_CDISC_pilot3.xml"), quiet = TRUE)
   )
 })
+
+test_that("Informative error when where_sep_sheet=TRUE but WhereClause sheet missing", {
+  # This should trigger the helpful error message about where_sep_sheet
+  expect_error(
+    spec_to_metacore(
+      "spec_no_val.xlsx", # Use relative path like the existing test
+      where_sep_sheet = TRUE, # This is the default, but being explicit
+      verbose = "silent"
+    ),
+    regexp = "where.*where_sep_sheet",
+    ignore.case = TRUE
+  )
+
+  # Verify the error message contains helpful context
+  err <- tryCatch(
+    spec_to_metacore(
+      "spec_no_val.xlsx",
+      where_sep_sheet = TRUE,
+      verbose = "silent"
+    ),
+    error = function(e) conditionMessage(e)
+  )
+
+  # Check that the error message mentions:
+  # 1. That columns couldn't be matched
+  expect_match(err, "Unable to identify a sheet|Could not find matching columns", ignore.case = TRUE)
+
+  # 2. Provides the helpful tip about where_sep_sheet
+  expect_match(err, "where_sep_sheet", ignore.case = TRUE)
+
+  # 3. Shows which sheet was closest
+  expect_match(err, "Sheet|Closest", ignore.case = TRUE)
+})


### PR DESCRIPTION
This may have been a typo from recent fixes for error messaging @LiamHobby @bms63 
Update from:
```

Error in `sheets_to_error %>% map2_chr(names(sheets_to_error), function(vars, sheet_name) {
    paste0("Sheet '", sheet_name, "' is the closest match, but unable to match the following column(s)\n",
      paste(names(vars), collapse = "\n"))
  }) %>% paste0(collapse = "\n") %>% paste0("Unable to identify a sheet with all columns.\n", .) %>%
    (call. = FALSE)`:
! attempt to apply non-function
``` 
to this:
```
Error:
! Unable to identify a sheet with all columns. Sheet 'Variables' is the closest match, but unable to match the following column(s)
  id where2 Sheet 'ValueLevel' is the closest match, but unable to match the following column(s) id where2 Sheet 'Codelists' is the closest
  match, but unable to match the following column(s) where1 where2 Sheet 'Analysis Results' is the closest match, but unable to match the
  following column(s) where2 where3
```
when loading the spec from `{pharmaverseadam}`: 
`mc <- spec_to_metacore("../pharmaverseadam/inst/extdata/adams-specs.xlsx", quiet = TRUE)`
